### PR TITLE
document release process with README_INTERNAL.md

### DIFF
--- a/README_INTERNAL.md
+++ b/README_INTERNAL.md
@@ -1,0 +1,10 @@
+# Release
+
+1. Get branch approved and merged
+1. Pull the updated master branch locally
+1. Run `npm version` - bump the version appropriately (this will commit and tag master)
+1. Push commit to github
+1. Run `yarn build`
+1. Run `npm publish` (your npm account will need to have publish access)
+1. After publishing, create a release in github and document the changes. Attach the build artifacts to the release.
+


### PR DESCRIPTION
Release 1.0.7 was never released to npm and the package.json
was not bumped on the tagged commit, so I think we should release
a new patch version