### PR TITLE
Add .abort() method

### DIFF
--- a/src/upchunk.ts
+++ b/src/upchunk.ts
@@ -38,6 +38,7 @@ export class UpChunk {
   private attemptCount: number;
   private offline: boolean;
   private paused: boolean;
+  private currentXhr?: XMLHttpRequest;
 
   private reader: FileReader;
   private eventTarget: EventTarget;
@@ -88,6 +89,11 @@ export class UpChunk {
    */
   public on(eventName: EventName, fn: (event: CustomEvent) => void) {
     this.eventTarget.addEventListener(eventName, fn);
+  }
+
+  public abort() {
+    this.pause();
+    this.currentXhr?.abort();
   }
 
   public pause() {
@@ -202,7 +208,8 @@ export class UpChunk {
     };
 
     return new Promise((resolve, reject) => {
-      xhr({ ...options, beforeSend }, (err, resp) => {
+      this.currentXhr = xhr({ ...options, beforeSend }, (err, resp) => {
+        this.currentXhr = undefined;
         if (err) {
           return reject(err);
         }


### PR DESCRIPTION
While pause stops the upload after the current request finishes, this additionally cancels the currently-in-flight request. I'm using upchunk for a file-uploader widget where the user can cancel the file upload. Pausing was ok, but completely aborting seems cleaner.

Overall, love the library. Super useful. Thanks!

Seems like this should have a spec, but I'm not sure the best way to test it? Is there a good example to follow?