### PR TITLE
Abort (PR #32) plus tests

### DIFF
--- a/src/upchunk.spec.ts
+++ b/src/upchunk.spec.ts
@@ -10,6 +10,7 @@ beforeEach(() => {
 
 afterEach(() => {
   nock.restore();
+  nock.cleanAll();
 });
 
 const createUploadFixture = (
@@ -27,10 +28,10 @@ const createUploadFixture = (
 };
 
 test('files can be uploading using POST', (done) => {
-  const scope = nock('https://example.com')
+  nock('https://example.com')
     .post('/upload/endpoint')
+    .twice()
     .reply(200)
-    .persist();
 
   const upload = createUploadFixture({
     method: 'POST',
@@ -42,10 +43,10 @@ test('files can be uploading using POST', (done) => {
 });
 
 test('files can be uploading using PATCH', (done) => {
-  const scope = nock('https://example.com')
+  nock('https://example.com')
     .patch('/upload/endpoint')
-    .reply(200)
-    .persist();
+    .twice()
+    .reply(200);
 
   const upload = createUploadFixture({
     method: 'PATCH',
@@ -94,7 +95,7 @@ test('a file is uploaded using the correct content-range headers', (done) => {
 });
 
 test('an error is thrown if a request does not complete', (done) => {
-  const scope = nock('https://example.com').put('/upload/endpoint').reply(500);
+  nock('https://example.com').put('/upload/endpoint').reply(500);
 
   const upload = createUploadFixture();
 
@@ -135,7 +136,7 @@ test('fires an attempt event before each attempt', (done) => {
 });
 
 test('a chunk failing to upload fires an attemptFailure event', (done) => {
-  const scope = nock('https://example.com').put('/upload/endpoint').reply(502);
+  nock('https://example.com').put('/upload/endpoint').reply(502);
 
   const upload = createUploadFixture();
 
@@ -244,14 +245,14 @@ test('abort pauses the upload and cancels the current XHR request', (done) => {
 
   upload.on('attempt', (e) => {
     setTimeout(() => {
-      if (scope.isDone()) {
-        expect(chunkSuccessCallback).toHaveBeenCalledTimes(0);
-        done();
-      }
+      expect(scope.isDone()).toBeTruthy();
+      expect(chunkSuccessCallback).toHaveBeenCalledTimes(0);
+      done();
     }, 100);
   });
 
-  upload.on('chunkSuccess', chunkSuccessCallback);
+  // upload.on('chunkSuccess', chunkSuccessCallback);
+  upload.on('chunkSuccess', (e) => console.log(e.detail))
 
   upload.on('success', () => {
     done('Upload should not have successfully completed');

--- a/src/upchunk.spec.ts
+++ b/src/upchunk.spec.ts
@@ -221,7 +221,7 @@ test('chunkSuccess event is fired after each successful upload', (done) => {
   });
 });
 
-test.only('abort pauses the upload and cancels the current XHR request', (done) => {
+test('abort pauses the upload and cancels the current XHR request', (done) => {
   /*
     This is hacky and I don't love it, but the gist is:
     - Set up a chunkSuccess callback listener
@@ -248,7 +248,7 @@ test.only('abort pauses the upload and cancels the current XHR request', (done) 
         expect(chunkSuccessCallback).toHaveBeenCalledTimes(0);
         done();
       }
-    }, 50);
+    }, 100);
   });
 
   upload.on('chunkSuccess', chunkSuccessCallback);

--- a/src/upchunk.spec.ts
+++ b/src/upchunk.spec.ts
@@ -248,7 +248,7 @@ test('abort pauses the upload and cancels the current XHR request', (done) => {
       expect(scope.isDone()).toBeTruthy();
       expect(chunkSuccessCallback).toHaveBeenCalledTimes(0);
       done();
-    }, 100);
+    }, 10);
   });
 
   // upload.on('chunkSuccess', chunkSuccessCallback);

--- a/src/upchunk.spec.ts
+++ b/src/upchunk.spec.ts
@@ -1,6 +1,6 @@
 import * as nock from 'nock';
 
-import { createUpload, UpChunkOptions } from './upchunk';
+import { UpChunk, createUpload, UpChunkOptions } from './upchunk';
 
 beforeEach(() => {
   if (!nock.isActive()) {
@@ -111,7 +111,7 @@ test('fires an attempt event before each attempt', (done) => {
   let ATTEMPT_COUNT = 0;
   const MAX_ATTEMPTS = 2; // because we set the chunk size to 256kb, half of our file size in bytes.
 
-  const scope = nock('https://example.com')
+  nock('https://example.com')
     .put('/upload/endpoint')
     .reply(200)
     .put('/upload/endpoint')
@@ -199,5 +199,61 @@ test('a single chunk failing the max number of times fails the upload', (done) =
 
   upload.on('success', () => {
     done(`Expected upload to fail due to failed attempts`);
+  });
+});
+
+test('chunkSuccess event is fired after each successful upload', (done) => {
+  nock('https://example.com')
+    .put('/upload/endpoint')
+    .reply(200)
+    .put('/upload/endpoint')
+    .reply(200);
+
+  const upload = createUploadFixture();
+
+  const successCallback = jest.fn();
+
+  upload.on('chunkSuccess', successCallback);
+
+  upload.on('success', () => {
+    expect(successCallback).toBeCalledTimes(2);
+    done();
+  });
+});
+
+test.only('abort pauses the upload and cancels the current XHR request', (done) => {
+  /*
+    This is hacky and I don't love it, but the gist is:
+    - Set up a chunkSuccess callback listener
+    - We abort the upload during the first request stub before responding
+    - In the attempt callback, we'll set a short timeout, where we check if the scope is done, meaning all the stubs have been called. If that's the case, make sure that chunkSuccess was never called.
+  */
+  let upload: UpChunk;
+
+  const scope = nock('https://example.com')
+    .put('/upload/endpoint')
+    .reply(() => {
+      upload.abort();
+
+      return [200, 'success'];
+    });
+
+  upload = createUploadFixture();
+
+  const chunkSuccessCallback = jest.fn();
+
+  upload.on('attempt', (e) => {
+    setTimeout(() => {
+      if (scope.isDone()) {
+        expect(chunkSuccessCallback).toHaveBeenCalledTimes(0);
+        done();
+      }
+    }, 50);
+  });
+
+  upload.on('chunkSuccess', chunkSuccessCallback);
+
+  upload.on('success', () => {
+    done('Upload should not have successfully completed');
   });
 });

--- a/src/upchunk.ts
+++ b/src/upchunk.ts
@@ -45,6 +45,7 @@ export class UpChunk {
   private attemptCount: number;
   private offline: boolean;
   private paused: boolean;
+  private currentXhr?: XMLHttpRequest;
 
   private reader: FileReader;
   private eventTarget: EventTarget;
@@ -96,6 +97,11 @@ export class UpChunk {
    */
   public on(eventName: EventName, fn: (event: CustomEvent) => void) {
     this.eventTarget.addEventListener(eventName, fn);
+  }
+
+  public abort() {
+    this.pause();
+    this.currentXhr?.abort();
   }
 
   public pause() {
@@ -210,7 +216,8 @@ export class UpChunk {
     };
 
     return new Promise((resolve, reject) => {
-      xhr({ ...options, beforeSend }, (err, resp) => {
+      this.currentXhr = xhr({ ...options, beforeSend }, (err, resp) => {
+        this.currentXhr = undefined;
         if (err) {
           return reject(err);
         }

--- a/src/upchunk.ts
+++ b/src/upchunk.ts
@@ -7,6 +7,7 @@ const TEMPORARY_ERROR_CODES = [408, 502, 503, 504]; // These error codes imply a
 type EventName =
   | 'attempt'
   | 'attemptFailure'
+  | 'chunkSuccess'
   | 'error'
   | 'offline'
   | 'online'
@@ -290,8 +291,15 @@ export class UpChunk {
         this.attemptCount = this.attemptCount + 1;
 
         if (SUCCESSFUL_CHUNK_UPLOAD_CODES.includes(res.statusCode)) {
+          this.dispatch('chunkSuccess', {
+            chunk: this.chunkCount,
+            attempts: this.attemptCount,
+            response: res,
+          });
+
           this.attemptCount = 0;
           this.chunkCount = this.chunkCount + 1;
+
           if (this.chunkCount < this.totalChunks) {
             this.sendChunks();
           } else {


### PR DESCRIPTION
Also adds a `chunkSuccess` event to make this test possible. That basically used to be what `progress` was since we only fired after a successful upload, but now that we fire on XHR progress that's not the case anymore.

Hrm, looks like there's something going on with the Nock mocks. Running this test by itself passes, but running it as part of the suite fails. Will dig in.