### PR TITLE
Increase default chunkSize to 30 MB

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ picker.onchange = () => {
   const upload = UpChunk.createUpload({
     endpoint: getUploadUrl,
     file: picker.files[0],
-    chunkSize: 5120, // Uploads the file in ~5mb chunks
+    chunkSize: 30720, // Uploads the file in ~30 MB chunks
   });
 
   // subscribe to events
@@ -109,7 +109,7 @@ function Page() {
       const upload = UpChunk.createUpload({
         endpoint: url, // Authenticated url
         file: inputRef.files[0], // File object with your video file’s properties
-        chunkSize: 5120, // Uploads the file in ~5mb chunks
+        chunkSize: 30720, // Uploads the file in ~30 MB chunks
       });
     
       // Subscribe to events
@@ -168,7 +168,7 @@ Returns an instance of `UpChunk` and begins uploading the specified `File`.
 
   An object with any headers you'd like included with the `PUT` request for each chunk.
 
-- `chunkSize` <small>type: `integer`, default:`5120`</small>
+- `chunkSize` <small>type: `integer`, default:`30720`</small>
 
   The size in kb of the chunks to split the file into, with the exception of the final chunk which may be smaller. This parameter should be in multiples of 256.
 

--- a/example/script.js
+++ b/example/script.js
@@ -6,7 +6,7 @@ picker.onchange = () => {
   const upload = UpChunk.createUpload({
     endpoint,
     file,
-    chunkSize: 5120,
+    chunkSize: 30720,
   });
 
   // subscribe to events

--- a/src/upchunk.ts
+++ b/src/upchunk.ts
@@ -59,7 +59,7 @@ export class UpChunk {
     this.file = options.file;
     this.headers = options.headers || ({} as XhrHeaders);
     this.method = options.method || 'PUT';
-    this.chunkSize = options.chunkSize || 5120;
+    this.chunkSize = options.chunkSize || 30720;
     this.attempts = options.attempts || 5;
     this.delayBeforeAttempt = options.delayBeforeAttempt || 1;
 


### PR DESCRIPTION
This drastically improves performance on faster connections, at the cost of potentially needing to retry a larger chunk of data when a connection is interrupted.

It's impossible to serve both fast and slow/unreliable internet connections well with a single fixed setting here, so in the future this should be made to scale dynamically to 1) maximize upload speed on fast connections, and 2) constrain the amount of time that will be wasted re-uploading a partial segment if it is interrupted.

I did not touch the version here, up to you how to deal with communicating this changed default.