### PR TITLE
update event-target-shim and typescript versions and typescript fixes

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,14 +37,14 @@
     "tslint": "^6.1.2",
     "tslint-config-airbnb": "^5.11.2",
     "tslint-config-prettier": "^1.18.0",
-    "typescript": "^3.9.5",
+    "typescript": "^4.1.3",
     "webpack": "^4.43.0",
     "webpack-cli": "^3.3.11",
     "webpack-dev-server": "^3.11.0",
     "webpack-merge": "^4.2.2"
   },
   "dependencies": {
-    "event-target-shim": "^4.0.3",
+    "event-target-shim": "^6.0.2",
     "xhr": "^2.6.0"
   },
   "volta": {

--- a/src/upchunk.ts
+++ b/src/upchunk.ts
@@ -102,7 +102,7 @@ export class UpChunk {
    * Subscribe to an event
    */
   public on(eventName: EventName, fn: (event: CustomEvent) => void) {
-    this.eventTarget.addEventListener(eventName, fn);
+    this.eventTarget.addEventListener(eventName, fn as EventListener);
   }
 
   public abort() {
@@ -128,7 +128,7 @@ export class UpChunk {
   private dispatch(eventName: EventName, detail?: any) {
     const event = new CustomEvent(eventName, { detail });
 
-    this.eventTarget.dispatchEvent(event);
+    this.eventTarget.dispatchEvent(event as any);
   }
 
   /**
@@ -198,7 +198,7 @@ export class UpChunk {
    * Get portion of the file of x bytes corresponding to chunkSize
    */
   private getChunk() {
-    return new Promise((resolve) => {
+    return new Promise<void> ((resolve) => {
       // Since we start with 0-chunkSize for the range, we need to subtract 1.
       const length =
         this.totalChunks === 1 ? this.file.size : this.chunkByteSize;

--- a/yarn.lock
+++ b/yarn.lock
@@ -2246,10 +2246,10 @@ etag@~1.8.1:
   resolved "https://registry.yarnpkg.com/etag/-/etag-1.8.1.tgz#41ae2eeb65efa62268aebfea83ac7d79299b0887"
   integrity sha1-Qa4u62XvpiJorr/qg6x9eSmbCIc=
 
-event-target-shim@^4.0.3:
-  version "4.0.3"
-  resolved "https://registry.yarnpkg.com/event-target-shim/-/event-target-shim-4.0.3.tgz#758cd632cd4241f5a73ceec64f93f0d7b0ae77d6"
-  integrity sha512-YXVJDPGzU0yhSzrXGoEFAByEaLnZXSlJDHXkq4Hp6WrlnV66tADiZugYf1utTaCP/dsYRcLndAhecbq9mnbbqg==
+event-target-shim@^6.0.2:
+  version "6.0.2"
+  resolved "https://registry.yarnpkg.com/event-target-shim/-/event-target-shim-6.0.2.tgz#ea5348c3618ee8b62ff1d344f01908ee2b8a2b71"
+  integrity sha512-8q3LsZjRezbFZ2PN+uP+Q7pnHUMmAOziU2vA2OwoFaKIXxlxl38IylhSSgUorWu/rf4er67w0ikBqjBFk/pomA==
 
 eventemitter3@^4.0.0:
   version "4.0.4"
@@ -6189,10 +6189,10 @@ typedarray@^0.0.6:
   resolved "https://registry.yarnpkg.com/typedarray/-/typedarray-0.0.6.tgz#867ac74e3864187b1d3d47d996a78ec5c8830777"
   integrity sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=
 
-typescript@^3.9.5:
-  version "3.9.5"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.9.5.tgz#586f0dba300cde8be52dd1ac4f7e1009c1b13f36"
-  integrity sha512-hSAifV3k+i6lEoCJ2k6R2Z/rp/H3+8sdmcn5NrS3/3kE7+RyZXm9aqvxWqjEXHAd8b0pShatpcdMTvEdvAJltQ==
+typescript@^4.1.3:
+  version "4.6.3"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.6.3.tgz#eefeafa6afdd31d725584c67a0eaba80f6fc6c6c"
+  integrity sha512-yNIatDa5iaofVozS/uQJEl3JRWLKKGJKh6Yaiv0GLGSuhpFJe7P3SbHZ8/yjAHRQwKRoA6YZqlfjXWmVzoVSMw==
 
 union-value@^1.0.0:
   version "1.0.1"


### PR DESCRIPTION
resolves #62 which was causing an infinite recursion when an event is dispatched.

* updated `event-target-shim` and `typescript` versions, made a couple typescript fixes in `upchunk.ts` to ensure tests still pass.
* not very knowledgeable with typescript, so if there's better ways to resolve the typescript issues that appear when upgrading typescript versions, would appreciate help on those

* if we can merge this in, it'll allow Sprig to use Mux's upchunk directly instead of our fork, which we've been using for some months now.