### PR TITLE
Allow custom content-range header

### DIFF
--- a/src/upchunk.ts
+++ b/src/upchunk.ts
@@ -248,9 +248,9 @@ export class UpChunk {
     const rangeStart = this.chunkCount * this.chunkByteSize;
     const rangeEnd = rangeStart + this.chunk.size - 1;
     const headers = {
-      ...this.headers,
       'Content-Type': this.file.type,
       'Content-Range': `bytes ${rangeStart}-${rangeEnd}/${this.file.size}`,
+      ...this.headers,      
     };
 
     this.dispatch('attempt', {


### PR DESCRIPTION
Moving when optional headers are applied to the end should allow overwriting the Content-Range header.

The primary need for overwriting this parameter is to pass custom content-range headers for when the size is unknown, such as a live recording in MediaRecorder.

```
UpChunk.createUpload({
  endpoint: url,
  file: file,
  headers : {
     'Content-Range': `bytes ${start}-${end}/*`,
});
```