### PR TITLE
allow sendChunk override

### DIFF
--- a/src/upchunk.ts
+++ b/src/upchunk.ts
@@ -246,9 +246,9 @@ export class UpChunk  {
   }
 
   /**
-   * Send chunk of the file with appropriate headers and add post parameters if it's last chunk
+   * Send chunk of the file with appropriate headers
    */
-  private sendChunk() {
+  protected async sendChunk() {
     const rangeStart = this.chunkCount * this.chunkByteSize;
     const rangeEnd = rangeStart + this.chunk.size - 1;
     const headers = {


### PR DESCRIPTION
While integrating UpChunk it might be necessary to adjust headers or do something else right before every chunk is sent over the network. For example, when other than mux backend is used, it is necessary to make sure that auth tokens are valid on every network call. The most flexible option could be additional `UpChunkOption` to provide such `onBeforeSend` callback and execute it later. However, inheritance can also be used and this one looks like the minimal change to the existing code.

Here is the usage example which will be less hacky and much safer after PR is approved and merged:
```js
class UpChunkExtended extends UpChunk {
    /**
     * DK: that's a real hack here.
     * We override private method in order to make sure that token is valid before sending any chunk.
     * I'll create follow-up pull request to original repository to make it properly
     *
     * @returns result of the call to the base class sendChunk method
     */
    private async sendChunk() {
        const token = await authApi.getOrRefreshAccessToken();

        this.headers['Authorization'] = 'Bearer ' + token;
        this.headers['x-functions-key'] = filesFunctionKey;

        // @ts-ignore
        return super.sendChunk();
    }
}
```