### PR TITLE
externalize retry codes

### DIFF
--- a/README.md
+++ b/README.md
@@ -176,11 +176,11 @@ Returns an instance of `UpChunk` and begins uploading the specified `File`.
 
   The maximum size of the file in kb of the input file to be uploaded. The maximum size can technically be smaller than the chunk size, and in that case there would be exactly one chunk.
 
-- `retries` <small>type: `integer`, default: `5`</small>
+- `attempts` <small>type: `integer`, default: `5`</small>
 
   The number of times to retry any given chunk.
 
-- `delayBeforeRetry` <small>type: `integer`, default: `1`</small>
+- `delayBeforeAttempt` <small>type: `integer`, default: `1`</small>
 
   The time in seconds to wait before attempting to upload a chunk again.
 

--- a/src/upchunk.ts
+++ b/src/upchunk.ts
@@ -32,6 +32,7 @@ export interface UpChunkOptions {
   chunkSize?: number;
   attempts?: number;
   delayBeforeAttempt?: number;
+  retryCodes?: number[];
 }
 
 export class UpChunk  {
@@ -42,6 +43,7 @@ export class UpChunk  {
   public chunkSize: number;
   public attempts: number;
   public delayBeforeAttempt: number;
+  public retryCodes: number[];
 
   private chunk: Blob;
   private chunkCount: number;
@@ -66,6 +68,7 @@ export class UpChunk  {
     this.chunkSize = options.chunkSize || 30720;
     this.attempts = options.attempts || 5;
     this.delayBeforeAttempt = options.delayBeforeAttempt || 1;
+    this.retryCodes = options.retryCodes || TEMPORARY_ERROR_CODES;
 
     this.maxFileBytes = (options.maxFileSize || 0) * 1024;
     this.chunkCount = 0;
@@ -332,7 +335,7 @@ export class UpChunk  {
           const percentProgress = (100 * uploadedBytes) / this.file.size;
 
           this.dispatch('progress', percentProgress);
-        } else if (TEMPORARY_ERROR_CODES.includes(res.statusCode)) {
+        } else if (this.retryCodes.includes(res.statusCode)) {
           if (this.paused || this.offline) {
             return;
           }


### PR DESCRIPTION
DONE:
 - updated `readme.md` to reflect actual option names
 - externalized `retryCodes` for better control over retries