### PR TITLE
Add dynamic chunk sizing

### DIFF
--- a/README.md
+++ b/README.md
@@ -214,10 +214,6 @@ Returns an instance of `UpChunk` and begins uploading the specified `File`.
 
   The same behavior as `pause()`, but also aborts the in-flight XHR request.
 
-- `getHistory()`
-
-  Retrieve the history of each chunk uploaded, the chunk size, and the time it took to upload each chunk.
-
 ### UpChunk Instance Events
 
 Events are fired with a [`CustomEvent`](https://developer.mozilla.org/en-US/docs/Web/API/CustomEvent/CustomEvent) object. The `detail` key is null if an interface isn't specified.

--- a/README.md
+++ b/README.md
@@ -170,7 +170,7 @@ Returns an instance of `UpChunk` and begins uploading the specified `File`.
 
 - `chunkSize` <small>type: `integer`, default:`30720`</small>
 
-  The size in kB of the chunks to split the file into, with the exception of the final chunk which may be smaller. This parameter should be in multiples of 256.
+  The size in kB of the chunks to split the file into, with the exception of the final chunk which may be smaller. This parameter must be in multiples of 256.
 
 - `maxFileSize` <small>type: `integer`</small>
 

--- a/README.md
+++ b/README.md
@@ -170,7 +170,7 @@ Returns an instance of `UpChunk` and begins uploading the specified `File`.
 
 - `chunkSize` <small>type: `integer`, default:`30720`</small>
 
-  The size in kb of the chunks to split the file into, with the exception of the final chunk which may be smaller. This parameter should be in multiples of 256.
+  The size in kB of the chunks to split the file into, with the exception of the final chunk which may be smaller. This parameter should be in multiples of 256.
 
 - `maxFileSize` <small>type: `integer`</small>
 
@@ -188,6 +188,18 @@ Returns an instance of `UpChunk` and begins uploading the specified `File`.
 
   The HTTP method to use when uploading each chunk.
 
+- `dynamicChunkSize` <small>type: `boolean`, default: `false`</small>
+
+  Whether or not the system should dynamically scale the `chunkSize` up and down to adjust to network conditions.
+
+- `maxChunkSize` <small>type: `integer`, default: `512000`</small>
+
+  When `dynamicChunkSize` is `true`, the largest chunk size that will be used, in kB.
+
+- `minChunkSize` <small>type: `integer`, default: `256`</small>
+
+  When `dynamicChunkSize` is `true`, the smallest chunk size that will be used, in kB.
+
 ### UpChunk Instance Methods
 
 - `pause()`
@@ -201,6 +213,10 @@ Returns an instance of `UpChunk` and begins uploading the specified `File`.
 - `abort()`
 
   The same behavior as `pause()`, but also aborts the in-flight XHR request.
+
+- `getHistory()`
+
+  Retrieve the history of each chunk uploaded, the chunk size, and the time it took to upload each chunk.
 
 ### UpChunk Instance Events
 

--- a/example/script.js
+++ b/example/script.js
@@ -6,10 +6,8 @@ picker.onchange = () => {
   const upload = UpChunk.createUpload({
     endpoint,
     file,
-    chunkSize: 16384,
-    dynamicChunkSize: true,
-    minChunkSize: 256,
-    maxChunkSize: 512000,
+    chunkSize: 30720,
+    dynamicChunkSize: false,
   });
 
   // subscribe to events

--- a/example/script.js
+++ b/example/script.js
@@ -22,6 +22,10 @@ picker.onchange = () => {
     console.log('There was an attempt!', detail);
   });
 
+  upload.on('chunkSuccess', ({ detail }) => {
+    console.log('Chunk successfully uploaded!', detail);
+  });
+
   upload.on('success', () => {
     console.log('We did it!');
   });

--- a/example/script.js
+++ b/example/script.js
@@ -33,6 +33,5 @@ picker.onchange = () => {
 
   upload.on('success', () => {
     console.log('We did it!');
-    console.log('Chunk history: ',upload.getChunkHistory());
   });
 };

--- a/example/script.js
+++ b/example/script.js
@@ -6,7 +6,10 @@ picker.onchange = () => {
   const upload = UpChunk.createUpload({
     endpoint,
     file,
-    chunkSize: 30720,
+    chunkSize: 16384,
+    dynamicChunkSize: true,
+    minChunkSize: 256,
+    maxChunkSize: 512000,
   });
 
   // subscribe to events
@@ -22,11 +25,16 @@ picker.onchange = () => {
     console.log('There was an attempt!', detail);
   });
 
+  upload.on('attemptFailure', ({ detail }) => {
+    console.log('The attempt failed!', detail);
+  });
+
   upload.on('chunkSuccess', ({ detail }) => {
     console.log('Chunk successfully uploaded!', detail);
   });
 
   upload.on('success', () => {
     console.log('We did it!');
+    console.log('Chunk history: ',upload.getChunkHistory());
   });
 };

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mux/upchunk",
-  "version": "2.4.0",
+  "version": "2.5.0",
   "description": "Dead simple chunked file uploads using Fetch",
   "main": "dist/upchunk.js",
   "module": "dist/upchunk.mjs",

--- a/package.json
+++ b/package.json
@@ -44,6 +44,7 @@
   },
   "devDependencies": {
     "@types/jest": "^25.2.3",
+    "@types/luxon": "^3.0.0",
     "esbuild": "^0.14.47",
     "jest": "^26.6.3",
     "nock": "^13.0.5",
@@ -57,6 +58,7 @@
   },
   "dependencies": {
     "event-target-shim": "^6.0.2",
+    "luxon": "^3.0.1",
     "xhr": "^2.6.0"
   },
   "volta": {

--- a/package.json
+++ b/package.json
@@ -44,7 +44,6 @@
   },
   "devDependencies": {
     "@types/jest": "^25.2.3",
-    "@types/luxon": "^3.0.0",
     "esbuild": "^0.14.47",
     "jest": "^26.6.3",
     "nock": "^13.0.5",

--- a/package.json
+++ b/package.json
@@ -58,7 +58,6 @@
   },
   "dependencies": {
     "event-target-shim": "^6.0.2",
-    "luxon": "^3.0.1",
     "xhr": "^2.6.0"
   },
   "volta": {

--- a/src/upchunk.spec.ts
+++ b/src/upchunk.spec.ts
@@ -282,7 +282,7 @@ test('progress event fires the correct upload percentage', (done) => {
         done('All scopes not completed');
       }
     });
-    expect(progressCallback).toHaveBeenCalledTimes(7);
+    expect(progressCallback).toHaveBeenCalledTimes(4);
     const progressPercentageArray = progressCallback.mock.calls.map(([percentage]) => percentage);
     expect(isNumberArraySorted(progressPercentageArray)).toBeTruthy();
     done();

--- a/src/upchunk.ts
+++ b/src/upchunk.ts
@@ -1,7 +1,6 @@
 import { EventTarget, Event } from 'event-target-shim';
 import xhr, { XhrUrlConfig, XhrHeaders, XhrResponse } from 'xhr';
 
-
 const SUCCESSFUL_CHUNK_UPLOAD_CODES = [200, 201, 202, 204, 308];
 const TEMPORARY_ERROR_CODES = [408, 502, 503, 504]; // These error codes imply a chunk may be retried
 
@@ -33,7 +32,17 @@ export interface UpChunkOptions {
   chunkSize?: number;
   attempts?: number;
   delayBeforeAttempt?: number;
+  dynamicChunkSize?: boolean;
+  maxChunkSize?: number;
+  minChunkSize?: number;
 }
+
+type chunkHistoryRecord = {
+  chunk: number,
+  attempts: number,
+  chunkSize: number,
+  timeInterval: number,
+};
 
 export class UpChunk  {
   public endpoint: string | ((file?: File) => Promise<string>);
@@ -57,6 +66,10 @@ export class UpChunk  {
   private success: boolean;
   private currentXhr?: XMLHttpRequest;
   private lastChunkStart: Date;
+  private chunkHistory: chunkHistoryRecord[];
+  private nextChunkRangeStart: number;
+  private maxChunkSize: number;
+  private minChunkSize: number;
 
   private reader: FileReader;
   private eventTarget: EventTarget<Record<EventName,UpchunkEvent>>;
@@ -71,6 +84,7 @@ export class UpChunk  {
     this.chunkSize = options.chunkSize || 30720;
     this.attempts = options.attempts || 5;
     this.delayBeforeAttempt = options.delayBeforeAttempt || 1;
+    this.dynamicChunkSize = options.dynamicChunkSize || false;
 
     this.maxFileBytes = (options.maxFileSize || 0) * 1024;
     this.chunkCount = 0;
@@ -80,6 +94,10 @@ export class UpChunk  {
     this.offline = false;
     this.paused = false;
     this.success = false;
+    this.chunkHistory = [];
+    this.nextChunkRangeStart = 0;
+    this.maxChunkSize = options.maxChunkSize || 512000; // in kB
+    this.minChunkSize = options.minChunkSize || 256; // in kB
 
     this.reader = new FileReader();
     this.eventTarget = new EventTarget();
@@ -161,11 +179,37 @@ export class UpChunk  {
     if (
       this.chunkSize &&
       (typeof this.chunkSize !== 'number' ||
-        this.chunkSize <= 0 ||
-        this.chunkSize % 256 !== 0)
+        this.chunkSize < 256 ||
+        this.chunkSize % 256 !== 0 ||
+        this.chunkSize < this.minChunkSize ||
+        this.chunkSize > this.maxChunkSize)
     ) {
       throw new TypeError(
-        'chunkSize must be a positive number in multiples of 256'
+        `chunkSize must be a positive number in multiples of 256, between ${this.minChunkSize} and ${this.maxChunkSize}`
+      );
+    }
+    if (
+      this.maxChunkSize &&
+      (typeof this.maxChunkSize !== 'number' ||
+        this.maxChunkSize < 256 ||
+        this.maxChunkSize % 256 !== 0 ||
+        this.maxChunkSize < this.chunkSize ||
+        this.maxChunkSize < this.minChunkSize)
+    ) {
+      throw new TypeError(
+        `maxChunkSize must be a positive number in multiples of 256, and larger than or equal to both ${this.minChunkSize} and ${this.chunkSize}`
+      );
+    }
+    if (
+      this.minChunkSize &&
+      (typeof this.minChunkSize !== 'number' ||
+        this.minChunkSize < 256 ||
+        this.minChunkSize % 256 !== 0 ||
+        this.minChunkSize > this.chunkSize ||
+        this.minChunkSize > this.maxChunkSize)
+    ) {
+      throw new TypeError(
+        `minChunkSize must be a positive number in multiples of 256, and smaller than ${this.chunkSize} and ${this.maxChunkSize}`
       );
     }
     if (this.maxFileBytes > 0 && this.maxFileBytes < this.file.size) {
@@ -211,7 +255,6 @@ export class UpChunk  {
       // Since we start with 0-chunkSize for the range, we need to subtract 1.
       const length =
         this.totalChunks === 1 ? this.file.size : this.chunkByteSize;
-      const start = length * this.chunkCount;
 
       this.reader.onload = () => {
         if (this.reader.result !== null) {
@@ -222,19 +265,20 @@ export class UpChunk  {
         resolve();
       };
 
-      this.reader.readAsArrayBuffer(this.file.slice(start, start + length));
+      this.reader.readAsArrayBuffer(this.file.slice(this.nextChunkRangeStart, this.nextChunkRangeStart + length));
     });
   }
 
   private xhrPromise(options: XhrUrlConfig): Promise<XhrResponse> {
     const beforeSend = (xhrObject: XMLHttpRequest) => {
       xhrObject.upload.onprogress = (event: ProgressEvent) => {
-        const percentagePerChunk = 100 / this.totalChunks;
-        const sizePerChunk = percentagePerChunk * this.file.size;
-        const successfulPercentage = percentagePerChunk * this.chunkCount;
-        const currentChunkProgress = event.loaded / (event.total ?? sizePerChunk);
+        const remainingChunks = this.totalChunks - this.chunkCount;
+        // const remainingBytes = this.file.size-(this.nextChunkRangeStart+event.loaded);
+        const percentagePerChunk = (this.file.size-this.nextChunkRangeStart)/this.file.size/remainingChunks;
+        const successfulPercentage = this.nextChunkRangeStart/this.file.size;
+        const currentChunkProgress = event.loaded / (event.total ?? this.chunkByteSize);
         const chunkPercentage = currentChunkProgress * percentagePerChunk;
-        this.dispatch('progress', Math.min(successfulPercentage + chunkPercentage, 100));
+        this.dispatch('progress', Math.min((successfulPercentage + chunkPercentage)*100, 100));
       };
     };
 
@@ -254,7 +298,7 @@ export class UpChunk  {
    * Send chunk of the file with appropriate headers
    */
   protected async sendChunk() {
-    const rangeStart = this.chunkCount * this.chunkByteSize;
+    const rangeStart = this.nextChunkRangeStart;
     const rangeEnd = rangeStart + this.chunk.size - 1;
     const headers = {
       ...this.headers,
@@ -264,7 +308,8 @@ export class UpChunk  {
 
     this.dispatch('attempt', {
       chunkNumber: this.chunkCount,
-      chunkSize: this.chunk.size,
+      totalChunks: this.totalChunks,
+      chunkSize: this.chunkSize,
     });
 
     return this.xhrPromise({
@@ -310,41 +355,63 @@ export class UpChunk  {
     this.getChunk()
       .then(() => {
         this.attemptCount = this.attemptCount + 1;
-	      this.lastChunkStart = new Date();
+        this.lastChunkStart = new Date();
         return this.sendChunk()
       })
       .then((res) => {
         if (SUCCESSFUL_CHUNK_UPLOAD_CODES.includes(res.statusCode)) {
           const lastChunkEnd = new Date();
-          const differenceSeconds = (lastChunkEnd.getTime() - this.lastChunkStart.getTime()) / 1000;
-            
-          this.dispatch('chunkSuccess', {
+          const lastChunkInterval = (lastChunkEnd.getTime() - this.lastChunkStart.getTime()) / 1000;
+
+          this.chunkHistory.push({
             chunk: this.chunkCount,
             attempts: this.attemptCount,
-            timeInterval: differenceSeconds,
+            chunkSize: this.chunk.size/1024,
+            timeInterval: lastChunkInterval,
+          });
+
+          this.dispatch('chunkSuccess', {
+            chunk: this.chunkCount,
+            chunkSize: this.chunkSize,
+            realChunkSize: this.chunk.size,
+            attempts: this.attemptCount,
+            timeInterval: lastChunkInterval,
             response: res,
           });
 
           this.attemptCount = 0;
           this.chunkCount = this.chunkCount + 1;
+          this.nextChunkRangeStart = this.nextChunkRangeStart + this.chunkByteSize;
 
           if (this.chunkCount < this.totalChunks) {
+            // dynamic chunk sizing
+            if (this.dynamicChunkSize) {
+              if (lastChunkInterval < 10)
+              {
+                this.chunkSize = Math.min(this.chunkSize * 2,this.maxChunkSize);
+              } else if (lastChunkInterval > 30) {
+                this.chunkSize = Math.max(this.chunkSize / 2,this.minChunkSize);
+              }
+
+              // Now update the new chunkByteSize to the newly calculated chunk size
+              this.chunkByteSize = this.chunkSize * 1024;
+
+              // Re-estimate the total number of chunks, by adding the completed
+              // chunks to the remaining chunks
+              const remainingChunks = (this.file.size-this.nextChunkRangeStart)/this.chunkByteSize;
+              this.totalChunks = Math.ceil(this.chunkCount + remainingChunks);
+            }
             this.sendChunks();
           } else {
             this.success = true;
             this.dispatch('success');
           }
 
-          const chunkFraction = this.chunkCount / this.totalChunks;
-          const uploadedBytes = chunkFraction * this.file.size;
-
-          const percentProgress = (100 * uploadedBytes) / this.file.size;
-
-          this.dispatch('progress', percentProgress);
         } else if (TEMPORARY_ERROR_CODES.includes(res.statusCode)) {
           if (this.paused || this.offline) {
             return;
           }
+	  console.warn('DEBUG: Caught a temporary error: %j',res);
           this.manageRetries();
         } else {
           if (this.paused || this.offline) {
@@ -363,9 +430,14 @@ export class UpChunk  {
           return;
         }
 
+	console.warn('DEBUG: Caught an error: %j',err);
         // this type of error can happen after network disconnection on CORS setup
         this.manageRetries();
       });
+  }
+
+  protected getChunkHistory() {
+    return this.chunkHistory;
   }
 }
 

--- a/src/upchunk.ts
+++ b/src/upchunk.ts
@@ -375,6 +375,8 @@ export class UpChunk  {
               } else if (lastChunkInterval > 30) {
                 this.chunkSize = Math.max(this.chunkSize / 2,this.minChunkSize);
               }
+              // ensure it's a multiple of 256k
+              this.chunkSize = Math.ceil(this.chunkSize / 256) * 256;
 
               // Now update the new chunkByteSize to the newly calculated chunk size
               this.chunkByteSize = this.chunkSize * 1024;
@@ -394,7 +396,7 @@ export class UpChunk  {
           if (this.paused || this.offline) {
             return;
           }
-	  // console.warn('DEBUG: Caught a temporary error: %j',res);
+          // console.warn('DEBUG: Caught a temporary error: %j',res);
           this.manageRetries();
         } else {
           if (this.paused || this.offline) {
@@ -413,7 +415,7 @@ export class UpChunk  {
           return;
         }
 
-	// console.warn('DEBUG: Caught an error: %j',err);
+        // console.warn('DEBUG: Caught an error: %j',err);
         // this type of error can happen after network disconnection on CORS setup
         this.manageRetries();
       });

--- a/src/upchunk.ts
+++ b/src/upchunk.ts
@@ -411,7 +411,7 @@ export class UpChunk  {
           if (this.paused || this.offline) {
             return;
           }
-	  console.warn('DEBUG: Caught a temporary error: %j',res);
+	  // console.warn('DEBUG: Caught a temporary error: %j',res);
           this.manageRetries();
         } else {
           if (this.paused || this.offline) {
@@ -430,7 +430,7 @@ export class UpChunk  {
           return;
         }
 
-	console.warn('DEBUG: Caught an error: %j',err);
+	// console.warn('DEBUG: Caught an error: %j',err);
         // this type of error can happen after network disconnection on CORS setup
         this.manageRetries();
       });

--- a/src/upchunk.ts
+++ b/src/upchunk.ts
@@ -319,7 +319,7 @@ export class UpChunk  {
       .then((res) => {
         if (SUCCESSFUL_CHUNK_UPLOAD_CODES.includes(res.statusCode)) {
           this.lastChunkEnd = DateTime.now();
-          this.lastChunkInterval = Interval.fromStartTimes(this.lastChunkStart,this.lastChunkEnd);
+          this.lastChunkInterval = Interval.fromDateTimes(this.lastChunkStart,this.lastChunkEnd);
           this.dispatch('chunkSuccess', {
             chunk: this.chunkCount,
             attempts: this.attemptCount,

--- a/src/upchunk.ts
+++ b/src/upchunk.ts
@@ -306,12 +306,12 @@ export class UpChunk  {
       .then(() => {
         this.attemptCount = this.attemptCount + 1;
 
-        const wrappedFn = this.timeWrapper(this.sendChunk())
-        wrappedFn()
+        const wrappedFn = this.timeWrapper(this.sendChunk)
+        return wrappedFn()
           .then((values)=>{
-            const {ret, elapsedTime} = values;
-            console.log(`ret:[${ret}] elapsedTime:[${elapsedTime}]`);
-            return ret;
+            const { returnValue, timeInterval } = values;
+            console.log(`ret:[${returnValue}] elapsedTime:[${timeInterval}]`);
+            return returnValue;
           })
       })
       .then((res) => {
@@ -365,18 +365,20 @@ export class UpChunk  {
       });
   }
 
-  const timeWrapper = (theFunction) => (...args) => {
-    const startTime = Date.now()
-    const thePromise = theFunction(...args)
-    if (!thePromise.then) {
-        throw 'The wrapped function must return a promise'
+  private timeWrapper<T>(theFunction: (...args: any[]) => Promise<T>) {
+    return function (...args: any[]) {
+      const startTime = Date.now()
+      const thePromise = theFunction(...args)
+      if (!thePromise.then) {
+          throw 'The wrapped function must return a promise'
+      }
+  
+      const timeInterval = (returnValue: T) => {
+          return {returnValue, timeInterval: Date.now() - startTime}
+      }
+  
+      return thePromise.then(timeInterval, timeInterval)
     }
-
-    const timeInterval = (returnValue) => {
-        return {returnValue, timeInterval: Date.now() - startTime}
-    }
-
-    return thePromise.then(timeInterval, timeInterval)
   }
 }
 

--- a/src/upchunk.ts
+++ b/src/upchunk.ts
@@ -37,13 +37,6 @@ export interface UpChunkOptions {
   minChunkSize?: number;
 }
 
-type chunkHistoryRecord = {
-  chunk: number,
-  attempts: number,
-  chunkSize: number,
-  timeInterval: number,
-};
-
 export class UpChunk  {
   public endpoint: string | ((file?: File) => Promise<string>);
   public file: File;
@@ -66,7 +59,6 @@ export class UpChunk  {
   private success: boolean;
   private currentXhr?: XMLHttpRequest;
   private lastChunkStart: Date;
-  private chunkHistory: chunkHistoryRecord[];
   private nextChunkRangeStart: number;
   private maxChunkSize: number;
   private minChunkSize: number;
@@ -94,7 +86,6 @@ export class UpChunk  {
     this.offline = false;
     this.paused = false;
     this.success = false;
-    this.chunkHistory = [];
     this.nextChunkRangeStart = 0;
     this.maxChunkSize = options.maxChunkSize || 512000; // in kB
     this.minChunkSize = options.minChunkSize || 256; // in kB
@@ -363,17 +354,9 @@ export class UpChunk  {
           const lastChunkEnd = new Date();
           const lastChunkInterval = (lastChunkEnd.getTime() - this.lastChunkStart.getTime()) / 1000;
 
-          this.chunkHistory.push({
-            chunk: this.chunkCount,
-            attempts: this.attemptCount,
-            chunkSize: this.chunk.size/1024,
-            timeInterval: lastChunkInterval,
-          });
-
           this.dispatch('chunkSuccess', {
             chunk: this.chunkCount,
             chunkSize: this.chunkSize,
-            realChunkSize: this.chunk.size,
             attempts: this.attemptCount,
             timeInterval: lastChunkInterval,
             response: res,
@@ -434,10 +417,6 @@ export class UpChunk  {
         // this type of error can happen after network disconnection on CORS setup
         this.manageRetries();
       });
-  }
-
-  protected getChunkHistory() {
-    return this.chunkHistory;
   }
 }
 

--- a/src/upchunk.ts
+++ b/src/upchunk.ts
@@ -306,7 +306,7 @@ export class UpChunk  {
       .then(() => {
         this.attemptCount = this.attemptCount + 1;
 
-        wrappedFn = this.timeWrapper(this.sendChunk())
+        const wrappedFn = this.timeWrapper(this.sendChunk())
         wrappedFn()
           .then((values)=>{
             const {ret, elapsedTime} = values;

--- a/yarn.lock
+++ b/yarn.lock
@@ -2801,11 +2801,6 @@ lru-cache@^6.0.0:
   dependencies:
     yallist "^4.0.0"
 
-luxon@^3.0.1:
-  version "3.0.1"
-  resolved "https://registry.yarnpkg.com/luxon/-/luxon-3.0.1.tgz#6901111d10ad06fd267ad4e4128a84bef8a77299"
-  integrity sha512-hF3kv0e5gwHQZKz4wtm4c+inDtyc7elkanAsBq+fundaCdUBNJB1dHEGUZIM6SfSBUlbVFduPwEtNjFK8wLtcw==
-
 make-dir@^3.0.0:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/make-dir/-/make-dir-3.1.0.tgz#415e967046b3a7f1d185277d84aa58203726a13f"

--- a/yarn.lock
+++ b/yarn.lock
@@ -635,6 +635,11 @@
     jest-diff "^25.2.1"
     pretty-format "^25.2.1"
 
+"@types/luxon@^3.0.0":
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/@types/luxon/-/luxon-3.0.0.tgz#47fb7891e41875fce7018a8bd3d09b204c5621f5"
+  integrity sha512-Lx+EZoJxUKw4dp8uei9XiUVNlgkYmax5+ovqt6Xf3LzJOnWhlfJw/jLBmqfGVwOP/pDr4HT8bI1WtxK0IChMLw==
+
 "@types/node@*":
   version "18.0.0"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-18.0.0.tgz#67c7b724e1bcdd7a8821ce0d5ee184d3b4dd525a"
@@ -2795,6 +2800,11 @@ lru-cache@^6.0.0:
   integrity sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==
   dependencies:
     yallist "^4.0.0"
+
+luxon@^3.0.1:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/luxon/-/luxon-3.0.1.tgz#6901111d10ad06fd267ad4e4128a84bef8a77299"
+  integrity sha512-hF3kv0e5gwHQZKz4wtm4c+inDtyc7elkanAsBq+fundaCdUBNJB1dHEGUZIM6SfSBUlbVFduPwEtNjFK8wLtcw==
 
 make-dir@^3.0.0:
   version "3.1.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -635,11 +635,6 @@
     jest-diff "^25.2.1"
     pretty-format "^25.2.1"
 
-"@types/luxon@^3.0.0":
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/@types/luxon/-/luxon-3.0.0.tgz#47fb7891e41875fce7018a8bd3d09b204c5621f5"
-  integrity sha512-Lx+EZoJxUKw4dp8uei9XiUVNlgkYmax5+ovqt6Xf3LzJOnWhlfJw/jLBmqfGVwOP/pDr4HT8bI1WtxK0IChMLw==
-
 "@types/node@*":
   version "18.0.0"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-18.0.0.tgz#67c7b724e1bcdd7a8821ce0d5ee184d3b4dd525a"


### PR DESCRIPTION
This adds dynamic chunk sizing to upchunk.  

There are three new options:
* dynamicChunkSize (boolean)
* minChunkSize (number)
* maxChunkSize (number)

The algorithm is somewhat primitive, but seems to work quite well in practice.  It starts off using the chunk size defined by `chunkSize`, and if that chunk takes less than 10 seconds, it doubles the size.  If a chunk takes more than 30 seconds, it halves the chunk size.  (Of course, looking out for minimums and maximums.)  