### PR TITLE
feat: Allow using a function to return extra headers

### DIFF
--- a/README.md
+++ b/README.md
@@ -165,9 +165,9 @@ Returns an instance of `UpChunk` and begins uploading the specified `File`.
 
   The file you'd like to upload. For example, you might just want to use the file from an input with a type of "file".
 
-- `headers` <small>type: `Object`</small>
+- `headers` <small>type: `Object` | `function`</small>
 
-  An object with any headers you'd like included with the `PUT` request for each chunk.
+  An object, a function that returns an object, or a function that returns a promise of an object. The resulting object contains any headers you'd like included with the `PUT` request for each chunk.
 
 - `chunkSize` <small>type: `integer`, default:`30720`</small>
 

--- a/test/upchunk.spec.js
+++ b/test/upchunk.spec.js
@@ -37,6 +37,13 @@ describe('option validation', () => {
     expect(upload).to.be.an.instanceOf(UpChunk);
   });
 
+  it('accepts a function that returns headers', () => {
+    const upload = createUpload(
+      buildParams({ headers: (() => {}) })
+    );
+    expect(upload).to.be.an.instanceOf(UpChunk);
+  })
+
   describe('throws', () => {
     it('endpoint is not included', () => {
       const params = buildParams({ endpoint: undefined });

--- a/test/upchunk.spec.ts
+++ b/test/upchunk.spec.ts
@@ -296,6 +296,60 @@ describe('integration', () => {
     }, 50);
   });
 
+  it('uses given headers', (done) => {
+    let requestHeaders = {};
+    xhrMock.put(endpoint, (req, res) => {
+      requestHeaders = req.headers();
+      return res.status(200);
+    });
+
+    const upload = createUploadFixture({
+      headers: { 'Authorization': 'Bearer token' },
+    });
+
+    upload.on('error', (err) => done(err));
+    upload.on('success', () => {
+      expect(requestHeaders).to.include({ 'authorization': 'Bearer token' });
+      done();
+    });
+  });
+
+  it('uses headers from headers function', (done) => {
+    let requestHeaders = {};
+    xhrMock.put(endpoint, (req, res) => {
+      requestHeaders = req.headers();
+      return res.status(200);
+    });
+
+    const upload = createUploadFixture({
+      headers: () => { return { 'Authorization': 'Bearer token' } },
+    });
+
+    upload.on('error', (err) => done(err));
+    upload.on('success', () => {
+      expect(requestHeaders).to.include({ 'authorization': 'Bearer token' });
+      done();
+    });
+  });
+
+  it('uses headers from headers function returning a promise', (done) => {
+    let requestHeaders = {};
+    xhrMock.put(endpoint, (req, res) => {
+      requestHeaders = req.headers();
+      return res.status(200);
+    });
+
+    const upload = createUploadFixture({
+      headers: () => Promise.resolve({ 'Authorization': 'Bearer token' }),
+    });
+
+    upload.on('error', (err) => done(err));
+    upload.on('success', () => {
+      expect(requestHeaders).to.include({ 'authorization': 'Bearer token' });
+      done();
+    });
+  });
+
   describe('upload validation', () => {
     it('should have identical bytes after chunked upload', (done) => {
       let uploadedBlob = new Blob();


### PR DESCRIPTION
When uploading large files to an authenticated endpoint, an authentication token given as `headers` to UpChunk might expire during upload operation. Allow also passing a function returning headers as a parameter so that current headers can be fetched before sending each chunk.