### PR TITLE
Change `createUpload` export to avoid ESBuild bug

### DIFF
--- a/src/upchunk.ts
+++ b/src/upchunk.ts
@@ -656,4 +656,6 @@ export class UpChunk {
   }
 }
 
-export const createUpload = UpChunk.createUpload;
+export function createUpload(options: UpChunkOptions) {
+  return new UpChunk(options);
+}


### PR DESCRIPTION
Fixes #111 by replacing the export of `createUpload` from a constant to a function.

When ESBuild with minimize flag, then passed to output, the constants before the class are not passed when exporting its static members as const.

Should be fixed in ESBuild, but this at least fixes UpChunk.