### PR TITLE
Change `createUpload` export

### DIFF
--- a/src/upchunk.ts
+++ b/src/upchunk.ts
@@ -656,4 +656,6 @@ export class UpChunk {
   }
 }
 
-export const createUpload = UpChunk.createUpload;
+export function createUpload(options: UpChunkOptions) {
+  return UpChunk.createUpload(options);
+}


### PR DESCRIPTION
Fixes #111 by replacing the exported constant function expression `createUpload` with a real function export.

This is an issue when compiling specific code with ESBuild (with minification), then bundling it with Webpack: https://github.com/mmvsk/bug-esbuild-min-webpack

The specific code is when there is a class with static methods that depend on previous variables (here the list of status codes), and when the static method is exported a function expression. Removing minification solves the issue, so it's very probably a problem inside ESBuild.

This fixes the problem for UpChunk.