### PR TITLE
build: replace esbuild iife dist with umd, using plugin developed for…

### DIFF
--- a/esbuild-umd.mjs
+++ b/esbuild-umd.mjs
@@ -1,0 +1,24 @@
+#!/usr/bin/env node
+
+import * as esbuild from 'esbuild';
+import { umdWrapper } from 'esbuild-plugin-umd-wrapper';
+
+const umdWrapperOptions = {
+  libraryName: 'UpChunk',
+};
+
+esbuild
+  .build({
+    entryPoints: ['src/upchunk.ts'],
+    target: 'es2019',
+    format: 'umd', // or "cjs"
+    bundle: true,
+    minify: true,
+    sourcemap: true,
+    outdir: './dist',
+    globalName: 'UpChunk',
+
+    plugins: [umdWrapper(umdWrapperOptions)],
+  })
+  .then((result) => console.log(result))
+  .catch(() => process.exit(1));

--- a/package.json
+++ b/package.json
@@ -36,11 +36,11 @@
     "tslint-check": "tslint-config-prettier-check ./tslint.json",
     "build:test": "esbuild ./test/deps/xhr-mock.ts ./test/deps/xhr.ts --target=es2019 --format=esm --bundle --minify --outdir=./test/dist --out-extension:.js=.mjs",
     "start": "esbuild      src/upchunk.ts --target=es2019 --format=iife --bundle --sourcemap --outdir=./example --global-name=UpChunk --servedir=example",
-    "build:iife": "esbuild src/upchunk.ts --target=es2019 --format=iife --bundle --minify --sourcemap --outdir=./dist    --global-name=UpChunk",
-    "build:esm": "esbuild  src/upchunk.ts --target=es2019 --format=esm  --bundle --minify --sourcemap --outdir=./dist --out-extension:.js=.mjs",
+    "build:umd": "node ./esbuild-umd.mjs",
+    "build:esm": "esbuild  src/upchunk.ts --target=es2019 --format=esm  --bundle --sourcemap --outdir=./dist --out-extension:.js=.mjs",
     "build:cjs": "esbuild  src/upchunk.ts --target=es2019 --format=cjs  --bundle --minify --sourcemap --outdir=./dist --out-extension:.js=.cjs.js",
     "build:types": "tsc --declaration --emitDeclarationOnly --outDir './dist'",
-    "build:all": "npm-run-all --parallel build:types build:esm build:cjs build:iife",
+    "build:all": "npm-run-all --parallel build:types build:esm build:cjs build:umd",
     "build": "yarn clean && yarn lint && yarn build:all && yarn pack"
   },
   "devDependencies": {
@@ -49,6 +49,7 @@
     "@web/dev-server-import-maps": "^0.0.7",
     "@web/test-runner": "^0.15.0",
     "esbuild": "^0.14.47",
+    "esbuild-plugin-umd-wrapper": "^2.0.0",
     "npm-run-all": "^4.1.5",
     "rimraf": "^3.0.2",
     "tslint": "^6.1.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1337,6 +1337,11 @@ esbuild-openbsd-64@0.14.54:
   resolved "https://registry.yarnpkg.com/esbuild-openbsd-64/-/esbuild-openbsd-64-0.14.54.tgz#db4c8495287a350a6790de22edea247a57c5d47b"
   integrity sha512-Qyk7ikT2o7Wu76UsvvDS5q0amJvmRzDyVlL0qf5VLsLchjCa1+IAvd8kTBgUxD7VBUUVgItLkk609ZHUc1oCaw==
 
+esbuild-plugin-umd-wrapper@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/esbuild-plugin-umd-wrapper/-/esbuild-plugin-umd-wrapper-2.0.0.tgz#93ace8dd64967dc1513fd1d9cf3437d873458c7d"
+  integrity sha512-pcu2/lcm29S85VCnSJuValrQ8FqeFJs5VWEwfp7vBRsOHjxZypcxgwXjxDIxDRo17uOcENZIbgz2szjln029eQ==
+
 esbuild-sunos-64@0.14.47:
   version "0.14.47"
   resolved "https://registry.yarnpkg.com/esbuild-sunos-64/-/esbuild-sunos-64-0.14.47.tgz#3f19612dcdb89ba6c65283a7ff6e16f8afbf8aaa"


### PR DESCRIPTION
… this case.

Currently, `esbuild` does not support and may never natively support a `umd` target (See: https://github.com/evanw/esbuild/issues/507). However, many build tools or default configurations for web app framework scaffolding tools still unfortunately make a variety of assumptions that result in `iife` targets insufficient as a "fallback" case (our current strategy). Luckily, since the primary difference between `esbuild`s `iife` and a `umd` build is header/footer content in the resultant .js file (with some *'s around e.g. bundled vs. unbundled that are irrelevant to our usage), someone has built a plugin for this 🎉 (See: https://github.com/Inqnuam/esbuild-plugin-umd-wrapper). 

This PR replaces our `iife` build (and its corresponding identifications in package.json) with a `umd` flavor instead. Furthermore, I've confirmed that this resolves the default `parcel` usage locally via a local link.

This will hopefully also resolve the various other build scenarios called out in #88 