### PR TITLE
Add response objects into failure events details.

### DIFF
--- a/src/upchunk.ts
+++ b/src/upchunk.ts
@@ -582,6 +582,7 @@ export class UpChunk {
         }. Stopping upload.`,
         chunk: this.chunkCount,
         attempts: this.attemptCount,
+        response: res,
       });
 
       return false;
@@ -590,7 +591,7 @@ export class UpChunk {
     // What to do if a chunk upload failed but is retriable and hasn't exceeded retry
     // count
     const retriableChunkUploadCb = async (
-      _res: XhrResponse | undefined,
+      res: XhrResponse | undefined,
       _chunk?: Blob
     ) => {
       // Side effects
@@ -600,6 +601,7 @@ export class UpChunk {
         } retries left.`,
         chunkNumber: this.chunkCount,
         attemptsLeft: this.attempts - this.attemptCount,
+        response: res,
       });
 
       return new Promise<boolean>((resolve) => {

--- a/test/upchunk.spec.ts
+++ b/test/upchunk.spec.ts
@@ -102,6 +102,7 @@ describe('integration', () => {
     const upload = createUploadFixture();
 
     upload.on('error', (err) => {
+      expect(err.detail.response.statusCode).to.equal(500);
       done();
     });
 
@@ -141,6 +142,7 @@ describe('integration', () => {
 
     upload.on('attemptFailure', (err) => {
       upload.pause();
+      expect(err.detail.response.statusCode).to.equal(502);
       done();
     });
   });


### PR DESCRIPTION
This PR resolves issue #128 by incorporating response objects from the request failure handlers directly into the details of the corresponding issues.