### PR TITLE
Bump for 3.4.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mux/upchunk",
-  "version": "3.3.3",
+  "version": "3.4.0",
   "description": "Dead simple chunked file uploads using Fetch",
   "main": "dist/upchunk.js",
   "module": "dist/upchunk.mjs",


### PR DESCRIPTION
Release for fallback to olde timey in mem file read (for Safari + >=4GB woes)