### PR TITLE
fix: handle edge case for resuming chunk upload case where multiple c…

### DIFF
--- a/src/upchunk.ts
+++ b/src/upchunk.ts
@@ -299,7 +299,10 @@ export const isIncompleteChunkUploadNeedingRetry = (
   }
 
   const endByte = parseInt(range[2], 10);
-  return endByte !== _options.currentChunkEndByte;
+  // NOTE: Since the endpoint may have been used previously and uploaded multiple chunks,
+  // only treat as an incomplete chunk upload if the end byte from the response header is
+  // less than the current chunk's end byte.
+  return endByte < _options.currentChunkEndByte;
 };
 
 type EventName =


### PR DESCRIPTION
…hunks have previously been uploaded.

NOTE: With the prior logic, if an upload encountered this scenario, it would get stuck (re)trying to upload the chunk it was already on (most likely the first chunk).