### PR TITLE
Bump for 3.5.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mux/upchunk",
-  "version": "3.4.0",
+  "version": "3.5.0",
   "description": "Dead simple chunked file uploads using Fetch",
   "main": "dist/upchunk.js",
   "module": "dist/upchunk.mjs",


### PR DESCRIPTION
- fix: handle edge case for resuming chunk upload case where multiple chunks have previously been uploaded. (#141)
- feat: dispatch error when endpoint promise fails to provide a string (#151)