### PR TITLE
Add 0 to list of retry codes

### DIFF
--- a/src/upchunk.ts
+++ b/src/upchunk.ts
@@ -248,7 +248,7 @@ export class ChunkedFileIterable implements ChunkedIterable {
 }
 
 const SUCCESSFUL_CHUNK_UPLOAD_CODES = [200, 201, 202, 204, 308];
-const TEMPORARY_ERROR_CODES = [408, 502, 503, 504]; // These error codes imply a chunk may be retried
+const TEMPORARY_ERROR_CODES = [408, 502, 503, 504, 0]; // These error codes imply a chunk may be retried
 const RESUME_INCOMPLETE_CODES = [308];
 
 type UploadPredOptions = {


### PR DESCRIPTION
The error `ERR_NETWORK_CHANGED` returns status code 0, and happens when switching from Wi-Fi networks, or during a brief wifi signal interruption.  Library should handle such cases gracefully.  

Was mentioned in [this closed issue](https://github.com/muxinc/upchunk/issues/149).